### PR TITLE
Further tweaks to Bullets

### DIFF
--- a/source/kmemo.pas
+++ b/source/kmemo.pas
@@ -112,16 +112,13 @@ const
   cSpaceChar = #$B7;
   { This is the character for tab visualisation. }
   cTabChar = #$2192;
-  { This is the character for standard bullet. }
-  cBullet = #$2022;
-  { This is the character for square bullet. }
-  cBrokenArrowBullet = #$21E2;                           // https://en.wikipedia.org/wiki/Arrows_(Unicode_block)
-  { This is the character for arrow bullet. }
-  cArrowBullet = #$21E8;                                 // https://en.wikipedia.org/wiki/Arrows_(Unicode_block)
-  { This is the character for circle bullet. }
-  cCircleBullet = #$2218;                                // https://en.wikipedia.org/wiki/Mathematical_Operators_(Unicode_block)
-  { This is the character for the small triangle bullet }
+  { These are Bullet Characters. }
   cTriangleBullet = #$2023;
+  cRoundBullet = #$2022;
+  cArrowTwoBullet = #$21A6;               // https://en.wikipedia.org/wiki/Arrows_(Unicode_block)
+  cArrowOneBullet = #$21A3;               // https://en.wikipedia.org/wiki/Arrows_(Unicode_block)
+  cCircleBullet = #$2218;                 // https://en.wikipedia.org/wiki/Mathematical_Operators_(Unicode_block)
+
 
   { Default characters used to break the text words. }
   cDefaultWordBreaks = [cNULL, cSPACE, '/', '\', ';', ':', '(', ')', '[', ']', '.', ',', '?', '!'];
@@ -256,8 +253,8 @@ type
     property Items[Index: Integer]: TKMemoDictionaryItem read GetItem write SetItem; default;
   end;
 
-  TKMemoParaNumbering = (pnuNone, pnuTriangleBullets, pnuBullets, pnuCircleBullets, pnuArrowBullets, pnuBrokenArrowBullets,  pnuArabic, pnuLetterLo, pnuLetterHi, pnuRomanLo, pnuRomanHi);
-
+  TKMemoParaNumbering = (pnuNone, pnuTriangleBullets, pnuBullets, pnuCircleBullets, pnuArrowOneBullets, pnuArrowTwoBullets,  pnuArabic, pnuLetterLo, pnuLetterHi, pnuRomanLo, pnuRomanHi);
+  // punBullets retained for compatibility with previous versions of KMemo
   TKMemoNumberingFormatItem = class(TKObject)
   private
     FLevel: Integer;
@@ -2804,15 +2801,15 @@ begin
   case ANumbering of
     pnuBullets:
     begin
-      AddItem(-1, UnicodeToNativeUTF(cBullet));
+      AddItem(-1, UnicodeToNativeUTF(cRoundBullet));
     end;
-    pnuBrokenArrowBullets:
+    pnuArrowTwoBullets:
     begin
-      AddItem(-1, UnicodeToNativeUTF(cBrokenArrowBullet));
+      AddItem(-1, UnicodeToNativeUTF(cArrowTwoBullet));
     end;
-    pnuArrowBullets:
+    pnuArrowOneBullets:
     begin
-      AddItem(-1, UnicodeToNativeUTF(cArrowBullet));
+      AddItem(-1, UnicodeToNativeUTF(cArrowOneBullet));
     end;
     pnuCircleBullets:
     begin
@@ -14621,7 +14618,7 @@ procedure TKMemoBlocks.UpdateAttributes;
         begin
           ItemLevel := List.Levels[Item.Level];
           Numbering := ItemLevel.Numbering;
-          if not (Numbering in [pnuNone, pnuBullets, pnuBrokenArrowBullets, pnuArrowBullets, pnuCircleBullets, pnuTriangleBullets]) then
+          if not (Numbering in [pnuNone, pnuBullets, pnuArrowTwoBullets, pnuArrowOneBullets, pnuCircleBullets, pnuTriangleBullets]) then
           begin
             LevelCounter := ItemLevel.LevelCounter;
             if AStyle.NumberStartAt > 0 then

--- a/source/kmemo.pas
+++ b/source/kmemo.pas
@@ -115,11 +115,13 @@ const
   { This is the character for standard bullet. }
   cBullet = #$2022;
   { This is the character for square bullet. }
-  cSquareBullet = #$25A0;
+  cBrokenArrowBullet = #$21E2;                           // https://en.wikipedia.org/wiki/Arrows_(Unicode_block)
   { This is the character for arrow bullet. }
-  cArrowBullet = #$25BA;
+  cArrowBullet = #$21E8;                                 // https://en.wikipedia.org/wiki/Arrows_(Unicode_block)
   { This is the character for circle bullet. }
-  cCircleBullet = #$25CB;
+  cCircleBullet = #$2218;                                // https://en.wikipedia.org/wiki/Mathematical_Operators_(Unicode_block)
+  { This is the character for the small triangle bullet }
+  cTriangleBullet = #$2023;
 
   { Default characters used to break the text words. }
   cDefaultWordBreaks = [cNULL, cSPACE, '/', '\', ';', ':', '(', ')', '[', ']', '.', ',', '?', '!'];
@@ -254,7 +256,7 @@ type
     property Items[Index: Integer]: TKMemoDictionaryItem read GetItem write SetItem; default;
   end;
 
-  TKMemoParaNumbering = (pnuNone, pnuBullets, pnuSquareBullets, pnuArrowBullets, pnuCircleBullets, pnuArabic, pnuLetterLo, pnuLetterHi, pnuRomanLo, pnuRomanHi);
+  TKMemoParaNumbering = (pnuNone, pnuTriangleBullets, pnuBullets, pnuCircleBullets, pnuArrowBullets, pnuBrokenArrowBullets,  pnuArabic, pnuLetterLo, pnuLetterHi, pnuRomanLo, pnuRomanHi);
 
   TKMemoNumberingFormatItem = class(TKObject)
   private
@@ -2804,9 +2806,9 @@ begin
     begin
       AddItem(-1, UnicodeToNativeUTF(cBullet));
     end;
-    pnuSquareBullets:
+    pnuBrokenArrowBullets:
     begin
-      AddItem(-1, UnicodeToNativeUTF(cSquareBullet));
+      AddItem(-1, UnicodeToNativeUTF(cBrokenArrowBullet));
     end;
     pnuArrowBullets:
     begin
@@ -2815,6 +2817,10 @@ begin
     pnuCircleBullets:
     begin
       AddItem(-1, UnicodeToNativeUTF(cCircleBullet));
+    end;
+    pnuTriangleBullets:
+    begin
+      AddItem(-1, UnicodeToNativeUTF(cTriangleBullet));
     end;
     pnuArabic, pnuLetterLo, pnuLetterHi, pnuRomanLo, pnuRomanHi:
     begin
@@ -14615,7 +14621,7 @@ procedure TKMemoBlocks.UpdateAttributes;
         begin
           ItemLevel := List.Levels[Item.Level];
           Numbering := ItemLevel.Numbering;
-          if not (Numbering in [pnuNone, pnuBullets, pnuSquareBullets, pnuArrowBullets, pnuCircleBullets]) then
+          if not (Numbering in [pnuNone, pnuBullets, pnuBrokenArrowBullets, pnuArrowBullets, pnuCircleBullets, pnuTriangleBullets]) then
           begin
             LevelCounter := ItemLevel.LevelCounter;
             if AStyle.NumberStartAt > 0 then

--- a/source/kmemortf.pas
+++ b/source/kmemortf.pas
@@ -994,7 +994,7 @@ end;
 procedure TKMemoRTFListLevel.SetNumberTypeAsNumbering(const Value: TKMemoParaNumbering);
 begin
   case Value of
-    pnuBullets, pnuTriangleBullets, pnuBrokenArrowBullets, pnuArrowBullets, pnuCircleBullets: FNumberType := 23; // maps to bullet, TODO: find out how other bullet styles are stored in RTF...
+    pnuBullets, pnuTriangleBullets, pnuArrowOneBullets, pnuArrowTwoBullets, pnuCircleBullets: FNumberType := 23; // maps to bullet, TODO: find out how other bullet styles are stored in RTF...
     pnuArabic: FNumberType := 0;
     pnuLetterLo: FNumberType := 4;
     pnuLetterHi: FNumberType := 3;

--- a/source/kmemortf.pas
+++ b/source/kmemortf.pas
@@ -994,7 +994,7 @@ end;
 procedure TKMemoRTFListLevel.SetNumberTypeAsNumbering(const Value: TKMemoParaNumbering);
 begin
   case Value of
-    pnuBullets, pnuSquareBullets, pnuArrowBullets, pnuCircleBullets: FNumberType := 23; // maps to bullet, TODO: find out how other bullet styles are stored in RTF...
+    pnuBullets, pnuTriangleBullets, pnuBrokenArrowBullets, pnuArrowBullets, pnuCircleBullets: FNumberType := 23; // maps to bullet, TODO: find out how other bullet styles are stored in RTF...
     pnuArabic: FNumberType := 0;
     pnuLetterLo: FNumberType := 4;
     pnuLetterHi: FNumberType := 3;


### PR DESCRIPTION
Hi TK, this relates to your issue #35 and note I have targeted MASTER, not a development branch, you don't seem to use branches.  If you would prefer this as a branch, please bounce it back.

I have increased the number of KMemo Bullet points to five and assigned a slightly different set of bullet point characters. The feeling was that some of the ones you used initially where just a bit 'loud' and did not make for nice looking text.

I have tested this code, the selected characters in particular, on Windows Vista (!), Windows 10, MacOS Sierra and Linux and they seem to work well. The code it self has only been tested on Lazarus, not Delphi. But I am pretty sure there is nothing there that should be a problem.

I'll add an image to the issue report of how it looks.

Hope you find this acceptable.

Davo