### PR TITLE
Spelling corrections to keep Lintian happy

### DIFF
--- a/source/keditcommon.pas
+++ b/source/keditcommon.pas
@@ -287,7 +287,7 @@ type
 
   { Declares possible values for the ErrorReason member of the @link(TKEditSearchData) structure }
   TKEditSearchError = (
-    { No error occured }
+    { No error occurred }
     eseOk,
     { There is a character in the search string that cannot be interpreted as hexadecimal digits}
     eseNoDigitsFind,

--- a/source/kgrids.pas
+++ b/source/kgrids.pas
@@ -1663,11 +1663,11 @@ type
     property BackColor: TColor read FBackColor write SetBackColor;
     { This is the brush that will be used to fill the cell background. }
     property Brush: TBrush read FBrush;
-    { Returns True if Brush.OnChange occured. }
+    { Returns True if Brush.OnChange occurred. }
     property BrushChanged: Boolean read FBrushChanged;
     { This is the font that will be used to render the text. }
     property Font: TFont read FFont;
-    { Returns True if Font.OnChange occured. }
+    { Returns True if Font.OnChange occurred. }
     property FontChanged: Boolean read FFontChanged;
     { This is the horizontal alignment
       that will be used to place the text within the cell rectangle. }


### PR DESCRIPTION
TK, this is really sounding trivial but I must ask.

KControls contains three instances of the word 'occured', a misspelling of occurred. They are all in comments and should not matter. But to Debian (sigh ...) they do matter. Their Lintian tool picks up the spelling in the source and complains.

Can you please accept this (stupidly trivial) pull request ?

Davo