### PR TITLE
Replaced several Lazarus UTF8 deprecated methods, all were redirects …

### DIFF
--- a/source/kfunctions.pas
+++ b/source/kfunctions.pas
@@ -1949,6 +1949,7 @@ begin
 end;
 
 function HexStrToInt(S: string; Digits: Integer; Signed: Boolean; var Code: Integer): Int64;
+
 var
   I, L, Len: Integer;
   N: Byte;
@@ -2375,7 +2376,7 @@ end;
 function StrNextCharIndex(const AText: TKString; Index: Integer): Integer;
 begin
 {$IFDEF FPC}
-  Result := Index + LazUTF8.UTF8CharacterLength(@AText[Index]);
+  Result := Index + LazUTF8.UTF8CodepointSize(@AText[Index]);
 {$ELSE}
   if (Word(AText[Index]) >= cUTF16FirstSurrogateBegin) and (Word(AText[Index]) <= cUTF16FirstSurrogateEnd) then
     Result := Index + 2
@@ -2387,7 +2388,7 @@ end;
 function StrPreviousCharIndex(const AText: TKString; Index: Integer): Integer;
 begin
 {$IFDEF FPC}
-  Result := Index - LazUTF8.UTF8CharacterLength(@AText[StringCharBegin(AText, Index - 1)]);
+  Result := Index - LazUTF8.UTF8CodepointSize(@AText[StringCharBegin(AText, Index - 1)]);
 {$ELSE}
   if (Word(AText[Index - 1]) >= cUTF16SecondSurrogateBegin) and (Word(AText[Index - 1]) <= cUTF16SecondSurrogateEnd) then
     Result := Index - 2
@@ -2405,7 +2406,7 @@ begin
   while I < ByteIndex do
   begin
   {$IFDEF FPC}
-    Inc(I, LazUTF8.UTF8CharacterLength(@AText[I]));
+    Inc(I, LazUTF8.UTF8CodepointSize(@AText[I]));
   {$ELSE}
     if (Word(AText[I]) >= cUTF16FirstSurrogateBegin) or (Word(AText[I]) > cUTF16FirstSurrogateEnd) then
       Inc(I, 2)
@@ -2424,7 +2425,7 @@ begin
   for I := 1 to CPIndex do
   begin
 {$IFDEF FPC}
-    Inc(Result, LazUTF8.UTF8CharacterLength(@AText[Result]));
+    Inc(Result, LazUTF8.UTF8CodepointSize(@AText[Result]));
 {$ELSE}
     if (Word(AText[Result]) >= cUTF16FirstSurrogateBegin) and (Word(AText[Result]) <= cUTF16FirstSurrogateEnd) then
       Inc(Result, 2)
@@ -2439,7 +2440,7 @@ end;
 function StringCharBegin(const AText: TKString; Index: Integer): Integer;
 begin
 {$IFDEF FPC}
-  Result := LazUTF8.UTF8CharToByteIndex(PChar(AText), Length(AText), Index)
+  Result := LazUTF8.UTF8CodepointToByteIndex(PChar(AText), Length(AText), Index)
 {$ELSE}
   if (Word(AText[Index - 1]) >= cUTF16SecondSurrogateBegin) and (Word(AText[Index - 1]) <= cUTF16SecondSurrogateEnd) then
     Result := Index - 1
@@ -2653,7 +2654,7 @@ var
 {$ENDIF}
 begin
 {$IFDEF FPC}
-  Result := WideChar(LazUTF8.UTF8CharacterToUnicode(PChar(AText), CharLen));
+  Result := WideChar(LazUTF8.UTF8CodepointToUnicode(PChar(AText), CharLen));
 {$ELSE}
   Result := AText[1];
 {$ENDIF}


### PR DESCRIPTION
…to new ones, no impact

TK, a number of FPC specific UTF8 deprecated methods. So, this affects FPC only and I have checked it with that.

Further, they offer absolutely no change anyway, the deprecated methods just called redirects to the one that they now use. So, we save, perhaps a pico second and might save a problem if the Lazarus Devs do remove those deprecated one as they threaten to do from time to time.

Anyway, a few less warnings is always good.

 Davo